### PR TITLE
Add Result type

### DIFF
--- a/lib/fe/maybe.ex
+++ b/lib/fe/maybe.ex
@@ -4,6 +4,10 @@ defmodule FE.Maybe do
   """
   @type t(a) :: {:just, a} | :nothing
 
+  defmodule Error do
+    defexception [:message]
+  end
+
   @doc """
   Creates a `FE.Maybe` representing a non-value.
   """
@@ -62,6 +66,18 @@ defmodule FE.Maybe do
   def unwrap_or(maybe, default)
   def unwrap_or(:nothing, default), do: default
   def unwrap_or({:just, value}, _), do: value
+
+  @doc """
+  Returns the value stored in a `FE.Maybe`, raises an `FE.Maybe.Error` if a non-value is passed.
+
+  ## Examples
+      iex> FE.Maybe.unwrap!(FE.Maybe.just(:value))
+      :value
+  """
+  @spec unwrap!(t(a)) :: a | no_return() when a: var
+  def unwrap!(maybe)
+  def unwrap!({:just, value}), do: value
+  def unwrap!(:nothing), do: raise(Error, "unwrapping Maybe that has no value")
 
   @doc """
   Applies value of `FE.Maybe` to a provided function and returns its return value,

--- a/lib/fe/maybe.ex
+++ b/lib/fe/maybe.ex
@@ -68,7 +68,7 @@ defmodule FE.Maybe do
   def unwrap_or({:just, value}, _), do: value
 
   @doc """
-  Returns the value stored in a `FE.Maybe`, raises an `FE.Maybe.Error` if a non-value is passed.
+  Returns the value stored in a `FE.Maybe`, raises a `FE.Maybe.Error` if a non-value is passed.
 
   ## Examples
       iex> FE.Maybe.unwrap!(FE.Maybe.just(:value))

--- a/lib/fe/maybe.ex
+++ b/lib/fe/maybe.ex
@@ -68,7 +68,7 @@ defmodule FE.Maybe do
   that should be of `FE.Maybe` type.
 
   Useful for chaining together a computation consisting of multiple steps, each of which
-  takes `FE.Maybe` as an argument and returns a `FE.Maybe`.
+  takes value wrapped in `FE.Maybe` as an argument and returns a `FE.Maybe`.
 
   ## Examples
       iex> FE.Maybe.and_then(FE.Maybe.nothing(), fn s -> FE.Maybe.just(String.length(s)) end)

--- a/lib/fe/result.ex
+++ b/lib/fe/result.ex
@@ -1,0 +1,56 @@
+defmodule FE.Result do
+  @moduledoc """
+  `FE.Result` is a data type for representing output of a computation that either succeed or fail.
+  """
+  @type t(a, b) :: {:ok, a} | {:error, b}
+  @type t(a) :: t(a, any)
+
+  @doc """
+  Creates a `FE.Result` representing a successful output of a computation.
+  """
+  @spec ok(a) :: t(a) when a: var
+  def ok(value), do: {:ok, value}
+
+  @doc """
+  Creates a `FE.Result` representing an errorneous output of a computation.
+  """
+  @spec error(a) :: t(any, a) when a: var
+  def error(value), do: {:error, value}
+
+  @doc """
+  Transforms a success value in a `FE.Result` using a provided function.
+
+  ## Examples
+      iex> FE.Result.map(FE.Result.error("foo"), &String.length/1)
+      FE.Result.error("foo")
+
+      iex> FE.Result.map(FE.Result.ok("foo"), &String.length/1)
+      FE.Result.ok(3)
+  """
+  @spec map(t(a, b), (a -> c)) :: t(c, b) when a: var, b: var, c: var
+  def map(result, f)
+  def map({:error, _} = error, _), do: error
+  def map({:ok, value}, f), do: {:ok, f.(value)}
+
+  @doc """
+  Applies success value of a `FE.Result` to a provided function and returns its return value,
+  that should be of `FE.Result` type.
+
+  Useful for chaining together a computation consisting of multiple steps, each of which
+  takes success value wrapped in `FE.Result` as an argument and returns a `FE.Result`.
+
+  ## Examples
+      iex> FE.Result.and_then(FE.Result.error("foo"), &FE.Result.ok(String.length(&1)))
+      FE.Result.error("foo")
+
+      iex> FE.Result.and_then(FE.Result.ok("bar"), &FE.Result.ok(String.length(&1)))
+      FE.Result.ok(3)
+
+      iex> FE.Result.and_then(FE.Result.ok("bar"), fn _ -> FE.Result.error(:baz) end)
+      FE.Result.error(:baz)
+  """
+  @spec and_then(t(a, b), (a -> t(c, b))) :: t(c, b) when a: var, b: var, c: var
+  def and_then(result, f)
+  def and_then({:error, _} = error, _), do: error
+  def and_then({:ok, value}, f), do: f.(value)
+end

--- a/lib/fe/result.ex
+++ b/lib/fe/result.ex
@@ -5,6 +5,10 @@ defmodule FE.Result do
   @type t(a, b) :: {:ok, a} | {:error, b}
   @type t(a) :: t(a, any)
 
+  defmodule Error do
+    defexception [:message]
+  end
+
   @doc """
   Creates a `FE.Result` representing a successful output of a computation.
   """
@@ -31,6 +35,29 @@ defmodule FE.Result do
   def map(result, f)
   def map({:error, _} = error, _), do: error
   def map({:ok, value}, f), do: {:ok, f.(value)}
+
+  @doc """
+  Returns the success value stored in a `FE.Result` or a provided default value if an error is passed.
+
+  ## Examples
+      iex> FE.Result.unwrap_or(FE.Result.error("foo"), "default")
+      "default"
+
+      iex> FE.Result.unwrap_or(FE.Result.ok("bar"), "default")
+      "bar"
+  """
+  @spec unwrap_or(t(a), a) :: a when a: var
+  def unwrap_or(result, default)
+  def unwrap_or({:error, _}, default), do: default
+  def unwrap_or({:ok, value}, _), do: value
+
+  @doc """
+  Returns the success value stored in a `FE.Result`, raises an `FE.Result.Error` if an error is passed.
+  """
+  @spec unwrap!(t(a)) :: a | no_return() when a: var
+  def unwrap!(result)
+  def unwrap!({:ok, value}), do: value
+  def unwrap!({:error, _}), do: raise(Error, "unwrapping Result with an error")
 
   @doc """
   Applies success value of a `FE.Result` to a provided function and returns its return value,

--- a/test/maybe_test.exs
+++ b/test/maybe_test.exs
@@ -47,4 +47,24 @@ defmodule FE.MaybeTest do
     assert Maybe.and_then(Maybe.just(5), fn x -> Maybe.just(x + 10) end) == Maybe.just(15)
     assert Maybe.and_then(Maybe.just("5"), fn _ -> Maybe.nothing() end) == Maybe.nothing()
   end
+
+  test "and_then chain stops on first nothing" do
+    result =
+      Maybe.just(1)
+      |> Maybe.and_then(&Maybe.just(&1 + 2))
+      |> Maybe.and_then(fn _ -> Maybe.nothing() end)
+      |> Maybe.and_then(&Maybe.just(&1 - 4))
+
+    assert result == Maybe.nothing()
+  end
+
+  test "and_then chain returns last if there is no nothing on the way" do
+    result =
+      Maybe.just(1)
+      |> Maybe.and_then(&Maybe.just(&1 + 2))
+      |> Maybe.and_then(&Maybe.just(&1 * 3))
+      |> Maybe.and_then(&Maybe.just(&1 - 4))
+
+    assert result == Maybe.just(5)
+  end
 end

--- a/test/maybe_test.exs
+++ b/test/maybe_test.exs
@@ -39,6 +39,17 @@ defmodule FE.MaybeTest do
     assert Maybe.unwrap_or(Maybe.just("five"), :ok) == "five"
   end
 
+  test "unwrap! returns just value is just is passed" do
+    assert Maybe.unwrap!(Maybe.just(3)) == 3
+    assert Maybe.unwrap!(Maybe.just("three")) == "three"
+  end
+
+  test "unwrap! raises an exception if non-value is passed" do
+    assert_raise FE.Maybe.Error, "unwrapping Maybe that has no value", fn ->
+      Maybe.unwrap!(Maybe.nothing())
+    end
+  end
+
   test "and_then returns nothing if nothing is passed" do
     assert Maybe.and_then(Maybe.nothing(), fn _ -> Maybe.nothing() end) == Maybe.nothing()
   end

--- a/test/result_test.exs
+++ b/test/result_test.exs
@@ -1,0 +1,50 @@
+defmodule FE.ResultTest do
+  use ExUnit.Case, async: true
+  doctest FE.Result
+
+  alias FE.Result
+
+  test "ok value can be created with a constructor" do
+    assert Result.ok(:foo) == {:ok, :foo}
+  end
+
+  test "error value can be created with a constructor" do
+    assert Result.error("bar") == {:error, "bar"}
+  end
+
+  test "mapping over an error returns the same error" do
+    assert Result.map(Result.error(:foo), fn _ -> :bar end) == Result.error(:foo)
+  end
+
+  test "mapping over an ok value applies function to value" do
+    assert Result.map(Result.ok(2), &(&1 * 5)) == Result.ok(10)
+  end
+
+  test "and_then returns error if an error is passed" do
+    assert Result.and_then(Result.error(5), fn x -> Result.ok(x * 2) end) == Result.error(5)
+  end
+
+  test "and_then applies function to the ok value that's passed" do
+    assert Result.and_then(Result.ok(5), fn x -> Result.ok(x * 2) end) == Result.ok(10)
+  end
+
+  test "and_then chain stops on first error" do
+    result =
+      Result.ok(1)
+      |> Result.and_then(&Result.ok(&1 + 2))
+      |> Result.and_then(&Result.error(&1 * 3))
+      |> Result.and_then(&Result.ok(&1 - 4))
+
+    assert result == Result.error(9)
+  end
+
+  test "and_then chain returns last if there is no error on the way" do
+    result =
+      Result.ok(1)
+      |> Result.and_then(&Result.ok(&1 + 2))
+      |> Result.and_then(&Result.ok(&1 * 3))
+      |> Result.and_then(&Result.ok(&1 - 4))
+
+    assert result == Result.ok(5)
+  end
+end

--- a/test/result_test.exs
+++ b/test/result_test.exs
@@ -4,11 +4,11 @@ defmodule FE.ResultTest do
 
   alias FE.Result
 
-  test "ok value can be created with a constructor" do
+  test "ok can be created with a constructor" do
     assert Result.ok(:foo) == {:ok, :foo}
   end
 
-  test "error value can be created with a constructor" do
+  test "error can be created with a constructor" do
     assert Result.error("bar") == {:error, "bar"}
   end
 
@@ -18,6 +18,26 @@ defmodule FE.ResultTest do
 
   test "mapping over an ok value applies function to value" do
     assert Result.map(Result.ok(2), &(&1 * 5)) == Result.ok(10)
+  end
+
+  test "unwrap_or returns default value if an error is passed" do
+    assert Result.unwrap_or(Result.error(:foo), :default) == :default
+    assert Result.unwrap_or(Result.error("bar"), nil) == nil
+  end
+
+  test "unwrap_or returns wrapped value if an ok is passed" do
+    assert Result.unwrap_or(Result.ok(:bar), :default) == :bar
+    assert Result.unwrap_or(Result.ok(3), :x) == 3
+  end
+
+  test "unwrap! returns wrapped value if an ok is passed" do
+    assert Result.unwrap!(Result.ok(:foo)) == :foo
+  end
+
+  test "unwrap! raises an exception if an error is passed" do
+    assert_raise FE.Result.Error, "unwrapping Result with an error", fn ->
+      Result.unwrap!(Result.error(:bar))
+    end
   end
 
   test "and_then returns error if an error is passed" do


### PR DESCRIPTION
What I think could be done next:
1. Implement `Functor` protocol (declares `map` function)
2. Implement `Monad` protocol (declares `and_then` function)

The problem with this approach is that in Elixir we can only define a new protocol for structs.
This means that the trade-off would be that nice pattern matching would require macros. Naughty, naughty.

I was also thinking about introducing another type that might be useful. Something like Haskell's [These](http://hackage.haskell.org/package/these/docs/Data-These.html).
So like `Result`, but so that we can still return a "successful" value and a list of errors that happened so far, until we return just a list of errors.
A use case for that is validation of fields, when we want to know about all the incorrect inputs.
Any idea for a good name for such a type?
