### PR TITLE
Add Result.map_error

### DIFF
--- a/lib/fe/result.ex
+++ b/lib/fe/result.ex
@@ -37,6 +37,21 @@ defmodule FE.Result do
   def map({:ok, value}, f), do: {:ok, f.(value)}
 
   @doc """
+  Transforms an errorneous value in a `FE.Result` using a provided function.
+
+  ## Examples
+      iex> FE.Result.map_error(FE.Result.ok("foo"), &String.length/1)
+      FE.Result.ok("foo")
+
+      iex> FE.Result.map_error(FE.Result.error("foo"), &String.length/1)
+      FE.Result.error(3)
+  """
+  @spec map_error(t(a, b), (b -> c)) :: t(a, c) when a: var, b: var, c: var
+  def map_error(result, f)
+  def map_error({:ok, _} = ok, _), do: ok
+  def map_error({:error, value}, f), do: {:error, f.(value)}
+
+  @doc """
   Returns the success value stored in a `FE.Result` or a provided default value if an error is passed.
 
   ## Examples

--- a/test/result_test.exs
+++ b/test/result_test.exs
@@ -20,6 +20,14 @@ defmodule FE.ResultTest do
     assert Result.map(Result.ok(2), &(&1 * 5)) == Result.ok(10)
   end
 
+  test "map_error over an ok value returns the same result" do
+    assert Result.map_error(Result.ok(3), fn _ -> :baz end) == Result.ok(3)
+  end
+
+  test "map_error over an error applies function to the error value" do
+    assert Result.map_error(Result.error(2), &(&1 * 3)) == Result.error(6)
+  end
+
   test "unwrap_or returns default value if an error is passed" do
     assert Result.unwrap_or(Result.error(:foo), :default) == :default
     assert Result.unwrap_or(Result.error("bar"), nil) == nil


### PR DESCRIPTION
This adds an option to map over an error value in `Result.t`.

A typical use case would be when we want to transform an internal data type that represents an error (like Elixir struct) to a generic datatype (map) that can be easily transformed to JSON.