### PR TITLE
Unwrap with

### DIFF
--- a/lib/fe/maybe.ex
+++ b/lib/fe/maybe.ex
@@ -74,16 +74,15 @@ defmodule FE.Maybe do
   Provides the value stored in `FE.Maybe` to the first function, or runs the second function.
 
   ## Examples
-      iex> FE.Maybe.unwrap_with(FE.Maybe.nothing(), fn(x) -> x+1 end, fn() -> :foo end)
+      iex> FE.Maybe.unwrap_with(FE.Maybe.nothing(), fn(x) -> x+1 end, :foo)
       :foo
 
-      iex> FE.Maybe.unwrap_with(FE.Maybe.just("a"), fn(x) -> x <> "bc" end, fn() -> "xyz" end)
+      iex> FE.Maybe.unwrap_with(FE.Maybe.just("a"), fn(x) -> x <> "bc" end, "xyz")
       "abc"
   """
-  @spec map(t(a), (a -> a)) :: t(a) when a: var
-  @spec unwrap_with(t(a), (a -> b), (() -> c)) :: b | c when a: var, b: var, c: var
-  def unwrap_with(maybe, on_just, on_nothing)
-  def unwrap_with(:nothing, _, on_nothing), do: on_nothing.()
+  @spec unwrap_with(t(a), (a -> b), b) :: b when a: var, b: var
+  def unwrap_with(maybe, on_just, default)
+  def unwrap_with(:nothing, _, default), do: default
   def unwrap_with({:just, value}, on_just, _), do: on_just.(value)
 
   @doc """

--- a/lib/fe/maybe.ex
+++ b/lib/fe/maybe.ex
@@ -71,7 +71,7 @@ defmodule FE.Maybe do
   def unwrap_or({:just, value}, _), do: value
 
   @doc """
-  Provides the value stored in `FE.Maybe` to the first function, or runs the second function.
+  Passes the value stored in `FE.Maybe` as input to the first function, or returns the provided default.
 
   ## Examples
       iex> FE.Maybe.unwrap_with(FE.Maybe.nothing(), fn(x) -> x+1 end, :foo)

--- a/lib/fe/maybe.ex
+++ b/lib/fe/maybe.ex
@@ -71,6 +71,22 @@ defmodule FE.Maybe do
   def unwrap_or({:just, value}, _), do: value
 
   @doc """
+  Provides the value stored in `FE.Maybe` to the first function, or runs the second function.
+
+  ## Examples
+      iex> FE.Maybe.unwrap_with(FE.Maybe.nothing(), fn(x) -> x+1 end, fn() -> :foo end)
+      :foo
+
+      iex> FE.Maybe.unwrap_with(FE.Maybe.just("a"), fn(x) -> x <> "bc" end, fn() -> "xyz" end)
+      "abc"
+  """
+  @spec map(t(a), (a -> a)) :: t(a) when a: var
+  @spec unwrap_with(t(a), (a -> b), (() -> c)) :: b | c when a: var, b: var, c: var
+  def unwrap_with(maybe, on_just, on_nothing)
+  def unwrap_with(:nothing, _, on_nothing), do: on_nothing.()
+  def unwrap_with({:just, value}, on_just, _), do: on_just.(value)
+
+  @doc """
   Returns the value stored in a `FE.Maybe`, raises a `FE.Maybe.Error` if a non-value is passed.
 
   ## Examples

--- a/test/maybe_test.exs
+++ b/test/maybe_test.exs
@@ -30,6 +30,10 @@ defmodule FE.MaybeTest do
     assert Maybe.map(Maybe.just("bar"), &String.length/1) == Maybe.just(3)
   end
 
+  test "unwrap_with applies the first function to just value" do
+    assert Maybe.unwrap_with(Maybe.just(5), &(&1 * 2), &(&1 - 5)) == 10
+  end
+
   test "unwrap_or returns default value if nothing is passed" do
     assert Maybe.unwrap_or(Maybe.nothing(), :default) == :default
   end

--- a/test/maybe_test.exs
+++ b/test/maybe_test.exs
@@ -31,7 +31,11 @@ defmodule FE.MaybeTest do
   end
 
   test "unwrap_with applies the first function to just value" do
-    assert Maybe.unwrap_with(Maybe.just(5), &(&1 * 2), &(&1 - 5)) == 10
+    assert Maybe.unwrap_with(Maybe.just(5), &(&1 * 2), :whatever) == 10
+  end
+
+  test "unwrap_with uses default value for nothing" do
+    assert Maybe.unwrap_with(Maybe.nothing(), &(&1 * 2), :whatever) == :whatever
   end
 
   test "unwrap_or returns default value if nothing is passed" do


### PR DESCRIPTION
This PR adds `unwrap_with` to the `Maybe` module, providing an analogous function to [`Data.Maybe.maybe`](http://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Maybe.html#v:maybe).
Sometimes, you want to 'escape' from the Maybe type into another chain (like Result), without taking extra steps, like:

```elixir
foo
|> Maybething()
|> MaybeOtherThing()
|> Maybe.unwrap_with(&some_computation_with_result_return_type/1, Result.error("quit early"))
```
This if for that use case.
