### PR TITLE
Add a curry function

### DIFF
--- a/lib/fe.ex
+++ b/lib/fe.ex
@@ -20,7 +20,7 @@ defmodule FE do
   Transforms a n-ary function in an unary one that accepts its first
   argument and returns a function expecting the next one, successively
   """
-  @spec curry((a, ... -> any())) :: (a -> any()) when a: var
+  @spec curry((... -> any())) :: (any() -> any())
   def curry(fun) do
     case :erlang.fun_info(fun, :arity) do
       {_, 0} -> raise ArgumentError, "0-ary functions cannot be curried"

--- a/lib/fe.ex
+++ b/lib/fe.ex
@@ -22,10 +22,12 @@ defmodule FE do
   """
   @spec curry((a, ... -> any())) :: (a -> any()) when a: var
   def curry(fun) do
-    {_, arity} = :erlang.fun_info(fun, :arity)
-    curry(fun, arity, [])
+    case :erlang.fun_info(fun, :arity) do
+      {_, 0} -> raise ArgumentError, "0-ary functions cannot be curried"
+      {_, arity} -> curry(fun, arity, [])
+    end
   end
-
+  
   defp curry(fun, 0, args) do
     apply(fun, Enum.reverse args)
   end

--- a/lib/fe.ex
+++ b/lib/fe.ex
@@ -15,4 +15,21 @@ defmodule FE do
   """
   @spec const(a) :: (any -> a) when a: var
   def const(a), do: fn _ -> a end
+  
+  @doc """
+  Transforms a n-ary function in an unary one that accepts its first
+  argument and returns a function expecting the next one, successively
+  """
+  @spec curry((a, ... -> any())) :: (a -> any()) when a: var
+  def curry(fun) do
+    {_, arity} = :erlang.fun_info(fun, :arity)
+    curry(fun, arity, [])
+  end
+
+  defp curry(fun, 0, args) do
+    apply(fun, Enum.reverse args)
+  end
+  defp curry(fun, arity, args) do
+    fn arg -> curry(fun, arity - 1, [arg | args]) end
+  end
 end


### PR DESCRIPTION
Adds a curry function to the main module that accepts >=1-ary functions and curries them.

I've added a docstring and an spec. The spec seems kind of poor but I don't think Elixir typespecs have more expressive power than that.

Resolves #13.